### PR TITLE
Fix broken map background

### DIFF
--- a/js/app/map.js
+++ b/js/app/map.js
@@ -177,9 +177,8 @@ define([
         };
 
         /* Background layer */
-        L.tileLayer('https://{s}.tiles.mapbox.com/v3/{id}/{z}/{x}/{y}.png', {
-            maxZoom: 18,
-            id: 'examples.map-i875mjb7'
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            maxZoom: 18
         }).addTo(map);
 
 

--- a/js/app/map.js
+++ b/js/app/map.js
@@ -136,7 +136,7 @@ define([
 
     function initMap(id, onclickHandler) {
 
-        var map = L.map(id,{
+        var map = L.map(id, {
             center: [-25, 120],
             zoom: 5,
             zoomControl: false,
@@ -166,9 +166,9 @@ define([
 
         // Control to display the region code on the bottom left
         var regionLabel;
-        var sidebarControl = function() {
+        var sidebarControl = function () {
             return new (L.Control.extend({
-                options: { position: 'bottomleft' },
+                options: {position: 'bottomleft'},
                 onAdd: function () {
                     regionLabel = L.DomUtil.create('div', 'sidebar-control');
                     return regionLabel;
@@ -177,9 +177,12 @@ define([
         };
 
         /* Background layer */
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            maxZoom: 18
-        }).addTo(map);
+        L.tileLayer('https://kmi.dpaw.wa.gov.au/geoserver/gwc/service/wmts?' +
+            'layer=dpaw:mapbox_outdoors&tilematrixset=mercator&Service=WMTS&Request=GetTile&Version=1.0.0' +
+            '&Format=image/png&TileMatrix=mercator:{z}&TileCol={x}&TileRow={y}',
+            {
+                maxZoom: 18
+            }).addTo(map);
 
 
         // The Ibra layer


### PR DESCRIPTION
Updated the map background to use Openstreet tiles instead of the Mapbox example that is now not available.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/parksandwildlife/biodiversityaudit2/2)
<!-- Reviewable:end -->
